### PR TITLE
Test that libcxx is used

### DIFF
--- a/recipe/test_sources/check_libcpp_def.cpp
+++ b/recipe/test_sources/check_libcpp_def.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+int main() {
+#ifdef _LIBCPP_VERSION
+    std::cout << "_LIBCPP_VERSION is " << _LIBCPP_VERSION << std::endl;
+    return 0;
+#else
+    std::cout << "_LIBCPP_VERSION is undefined." << std::endl;
+    return 1;
+#endif  // _LIBCPP_VERSION
+}


### PR DESCRIPTION
Simply add a test that will pass if `libcxx` is used, but fail otherwise. Does this by checking that `_LIBCPP_VERSION` is defined during compile time. If it is, then it creates a `main` function that passes otherwise it creates one that fails. In either case, it prints out a message informing either the value of `_LIBCPP_VERSION` or that `_LIBCPP_VERSION` is undefined.

Note: This still passes when using macOS system compilers. So it is not a foolproof test, but it should give us some confidence that at least some `libcxx` is used.