### PR TITLE
Revert "Don't use system libc++abi when building libc++"

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -8,8 +8,5 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-pin_run_as_build:
-  vc:
-    max_pin: x
 vc:
 - '14'

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -7,13 +7,10 @@ channel_targets:
 cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:
-- '*'
+- 9.0.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-pin_run_as_build:
-  vc:
-    max_pin: x
 vc:
 - '14'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,14 @@
+LLVM_PREFIX=$PREFIX
+
 if [[ "$target_platform" == "osx-64" ]]; then
     export CFLAGS="$CFLAGS -isysroot $CONDA_BUILD_SYSROOT"
     export CXXFLAGS="$CXXFLAGS -isysroot $CONDA_BUILD_SYSROOT"
     export LDFLAGS="$LDFLAGS -isysroot $CONDA_BUILD_SYSROOT"
 fi
 
-export CFLAGS="$CFLAGS -I$PREFIX/include -I$BUILD_PREFIX/include"
-export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib -L$BUILD_PREFIX/lib -Wl,-rpath,$BUILD_PREFIX/lib"
+export CFLAGS="$CFLAGS -I$LLVM_PREFIX/include -I$BUILD_PREFIX/include"
+export LDFLAGS="$LDFLAGS -L$LLVM_PREFIX/lib -Wl,-rpath,$LLVM_PREFIX/lib -L$BUILD_PREFIX/lib -Wl,-rpath,$BUILD_PREFIX/lib"
+export PATH="$LLVM_PREFIX/bin:$PATH"
 
 if [[ "$target_platform" != "osx-64" ]]; then
     # build libcxx first
@@ -22,53 +25,62 @@ if [[ "$target_platform" != "osx-64" ]]; then
     make -j${CPU_COUNT}
     make install
     cd ..
-fi
 
-if [[ "$target_platform" != "osx-64" ]]; then
-  LIBCXXABI_PREFIX=$PREFIX
+    # now build libcxxabi
+    cd libcxxabi
+    mkdir build && cd build
+
+    cmake \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DLIBCXXABI_LIBCXX_PATH=$SRC_DIR \
+      -DLIBCXXABI_LIBCXX_INCLUDES=$SRC_DIR/include \
+      -DLLVM_INCLUDE_TESTS=OFF \
+      -DLLVM_INCLUDE_DOCS=OFF \
+      ..
+
+    make -j${CPU_COUNT}
+    make install
+    cd ../..
+
+    # now rebuild libcxx with libcxxabi
+    mkdir build2
+    cd build2
+
+    cmake \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DLIBCXX_CXX_ABI=libcxxabi \
+      -DLIBCXX_CXX_ABI_INCLUDE_PATHS=$SRC_DIR/libcxxabi/include \
+      -DLIBCXX_CXX_ABI_LIBRARY_PATH=$PREFIX/lib \
+      -DLLVM_INCLUDE_TESTS=OFF \
+      -DLLVM_INCLUDE_DOCS=OFF \
+      ..
+
+    make -j${CPU_COUNT}
+    make install
+
+    cd ..
 else
-  LIBCXXABI_PREFIX=$BUILD_PREFIX
-fi
+    mkdir build
+    cd build
 
-# now build libcxxabi
-# This is needed on OSX to properly re-export the symbols for ABI version 2
-cd libcxxabi
-mkdir build && cd build
+    # on osx we point libc++ to the system libc++abi
+    cmake \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DLIBCXX_CXX_ABI=libcxxabi \
+      -DLIBCXX_CXX_ABI_INCLUDE_PATHS=${CONDA_BUILD_SYSROOT}/usr/include \
+      -DLIBCXX_CXX_ABI_LIBRARY_PATH=${CONDA_BUILD_SYSROOT}/usr/lib \
+      -DLLVM_INCLUDE_TESTS=OFF \
+      -DLLVM_INCLUDE_DOCS=OFF \
+      ..
 
-cmake \
-  -DCMAKE_INSTALL_PREFIX=$LIBCXXABI_PREFIX \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DLIBCXXABI_LIBCXX_PATH=$SRC_DIR \
-  -DLIBCXXABI_LIBCXX_INCLUDES=$SRC_DIR/include \
-  -DLLVM_INCLUDE_TESTS=OFF \
-  -DLLVM_INCLUDE_DOCS=OFF \
-  ..
+    make -j${CPU_COUNT}
+    make install
 
-make -j${CPU_COUNT}
-make install
-cd ../..
-
-# now rebuild libcxx with libcxxabi
-mkdir build2
-cd build2
-
-cmake \
-  -DCMAKE_INSTALL_PREFIX=$PREFIX \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DLIBCXX_CXX_ABI=libcxxabi \
-  -DLIBCXX_CXX_ABI_INCLUDE_PATHS=$SRC_DIR/libcxxabi/include \
-  -DLIBCXX_CXX_ABI_LIBRARY_PATH=$LIBCXXABI_PREFIX/lib \
-  -DLLVM_INCLUDE_TESTS=OFF \
-  -DLLVM_INCLUDE_DOCS=OFF \
-  ..
-
-make -j${CPU_COUNT}
-make install
-
-cd ..
-
-if [[ "$target_platform" == "osx-64" ]]; then
     # on osx we point libc++ to the system libc++abi
     $INSTALL_NAME_TOOL -change "@rpath/libc++abi.1.dylib" "/usr/lib/libc++abi.dylib" $PREFIX/lib/libc++.1.0.dylib
-    $NM -g $PREFIX/lib/libc++.dylib  | grep __ZNSt8bad_castD1Ev
+
+    cd ..
 fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,6 +11,6 @@ vc:
 python:
   - 3.7
 c_compiler_version:     # [osx]
-  - "*"                 # [osx]
+  - "9.0.0"             # [osx]
 cxx_compiler_version:   # [osx]
-  - "*"                 # [osx]
+  - "9.0.0"             # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     folder: libcxxabi  # [linux]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   skip: true  # [win]
   skip: true  # [ppc64le or aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,9 @@ source:
       # See https://bugs.llvm.org/show_bug.cgi?id=39696
       - ppc64le-constexpr.patch  # [ppc64le]
 
-  - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version }}/libcxxabi-{{ version }}.src.tar.xz
-    sha256: e71bac75a88c9dde455ad3f2a2b449bf745eafd41d2d8432253b2964e0ca14e1
-    folder: libcxxabi
+  - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version }}/libcxxabi-{{ version }}.src.tar.xz  # [linux]
+    sha256: e71bac75a88c9dde455ad3f2a2b449bf745eafd41d2d8432253b2964e0ca14e1  # [linux]
+    folder: libcxxabi  # [linux]
 
 build:
   number: 0


### PR DESCRIPTION
This reverts commit 6fc7fd83492c8c87774928e33f5c3455d2a1b1b3.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
