### PR TITLE
Add testing against older clangs on osx

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,11 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -75,6 +70,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,10 +85,17 @@ outputs:
 
       # Following 2 projects had issues with libc++, so check them
       # before releasing just to be sure.
-      downstreams:   # [osx]
-        - python-symengine  # [osx]
-        - openturns         # [osx]
-        - libcxx-testing    # [osx]
+      downstreams:              # [osx]
+        - python-symengine      # [osx]
+        - openturns             # [osx]
+        # test current libcxx against old clang builds;
+        # version correspondence is 0.{{ CLANG_MAJOR }}
+        - libcxx-testing 0.16   # [osx]
+        - libcxx-testing 0.15   # [osx]
+        - libcxx-testing 0.14   # [osx]
+        - libcxx-testing 0.13   # [osx]
+        - libcxx-testing 0.12   # [osx]
+        - libcxx-testing 0.11   # [osx]
 
   - name: libcxxabi
     build:


### PR DESCRIPTION
~This is my hypothesis, given that I hadn't noticed that the last `libcxx-testing` build still required clang 11! Should be fixed now by https://github.com/conda-forge/libcxx-testing-feedstock/pull/2~

See below