### PR TITLE
rc3, forward port testing improvements, rebase pre-C11 fallbacks

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,10 +87,17 @@ outputs:
 
       # Following 2 projects had issues with libc++, so check them
       # before releasing just to be sure.
-      downstreams:   # [osx]
-        - python-symengine  # [osx]
-        - openturns         # [osx]
-        - libcxx-testing    # [osx]
+      downstreams:              # [osx]
+        - python-symengine      # [osx]
+        - openturns             # [osx]
+        # test current libcxx against old clang builds;
+        # version correspondence is 0.{{ CLANG_MAJOR }}
+        - libcxx-testing 0.16   # [osx]
+        - libcxx-testing 0.15   # [osx]
+        - libcxx-testing 0.14   # [osx]
+        - libcxx-testing 0.13   # [osx]
+        - libcxx-testing 0.12   # [osx]
+        - libcxx-testing 0.11   # [osx]
 
   - name: libcxxabi
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "17.0.0.rc2" %}
+{% set version = "17.0.0.rc3" %}
 
 package:
   name: libcxx_and_libcxxabi
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
-    sha256: 71c018a6c0d3f7ccfe66a8ea7a68281a256fcd3bc35099e61616a92dcbbf0859
+    sha256: 60493f4e974fcca7b739aea4901af2d957b0eaea34b42815359be59cf6c88fa2
     patches:
       - patches/0001-Support-legacy-standalone-builds.patch
       # See https://lists.llvm.org/pipermail/libcxx-dev/2021-July/001172.html
@@ -19,7 +19,7 @@ source:
       - patches/0004-Revert-libc-Remove-workaround-for-C11-features-on-co.patch
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   skip: true  # [ppc64le or aarch64]
   ignore_run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,14 @@ source:
       # See https://lists.llvm.org/pipermail/libcxx-dev/2021-July/001172.html
       - patches/0002-Fix-ABI-compatibility-with-system.patch
       - patches/0003-custom-error-message-for-old-sdk.patch
+      # upstream removed fallbacks in case the underlying libc didn't support C11 in
+      # https://github.com/llvm/llvm-project/commit/21f73d5826fb5024a27eaacafadfa316f58949c5;
+      # using new libcxx with old clang versions (beyond what upstream supports) relies on
+      # having these fallbacks in place. Drop if conflict-resolution becomes too messy.
+      - patches/0004-Revert-libc-Remove-workaround-for-C11-features-on-co.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   skip: true  # [ppc64le or aarch64]
   ignore_run_exports:

--- a/recipe/patches/0001-Support-legacy-standalone-builds.patch
+++ b/recipe/patches/0001-Support-legacy-standalone-builds.patch
@@ -1,14 +1,14 @@
 From d29ac5318e8e94e0365f6f93547d1b6e97ac48e4 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Tue, 18 May 2021 19:51:28 -0500
-Subject: [PATCH 1/3] Support legacy standalone builds
+Subject: [PATCH 1/4] Support legacy standalone builds
 
 ---
  libcxx/src/CMakeLists.txt | 17 +++++++++++++++++
  1 file changed, 17 insertions(+)
 
 diff --git a/libcxx/src/CMakeLists.txt b/libcxx/src/CMakeLists.txt
-index 35b46652709..720a4b65b83 100644
+index 35b466527096..720a4b65b83c 100644
 --- a/libcxx/src/CMakeLists.txt
 +++ b/libcxx/src/CMakeLists.txt
 @@ -235,6 +235,23 @@ if (LIBCXX_ENABLE_SHARED)

--- a/recipe/patches/0002-Fix-ABI-compatibility-with-system.patch
+++ b/recipe/patches/0002-Fix-ABI-compatibility-with-system.patch
@@ -1,14 +1,14 @@
 From 123217eff2d5ceec3a0d7578d2c1256be6dc1943 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Tue, 13 Jul 2021 01:57:06 -0500
-Subject: [PATCH 2/3] Fix ABI compatibility with system
+Subject: [PATCH 2/4] Fix ABI compatibility with system
 
 ---
  libcxx/src/locale.cpp | 16 ++++++++--------
  1 file changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/libcxx/src/locale.cpp b/libcxx/src/locale.cpp
-index bd70a27be4e..a2062e5d3f5 100644
+index bd70a27be4ef..a2062e5d3f53 100644
 --- a/libcxx/src/locale.cpp
 +++ b/libcxx/src/locale.cpp
 @@ -193,10 +193,6 @@ _LIBCPP_SUPPRESS_DEPRECATED_PUSH

--- a/recipe/patches/0003-custom-error-message-for-old-sdk.patch
+++ b/recipe/patches/0003-custom-error-message-for-old-sdk.patch
@@ -1,14 +1,14 @@
 From 54fcf64308c718b275629a28678dcfcc90014205 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Dec 2021 19:28:35 -0800
-Subject: [PATCH 3/3] custom error message for old sdk
+Subject: [PATCH 3/4] custom error message for old sdk
 
 ---
  libcxx/include/__availability | 10 +++++-----
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/libcxx/include/__availability b/libcxx/include/__availability
-index 7807f22b716..94f6e070b93 100644
+index 7807f22b716f..94f6e070b936 100644
 --- a/libcxx/include/__availability
 +++ b/libcxx/include/__availability
 @@ -279,12 +279,12 @@

--- a/recipe/patches/0004-Revert-libc-Remove-workaround-for-C11-features-on-co.patch
+++ b/recipe/patches/0004-Revert-libc-Remove-workaround-for-C11-features-on-co.patch
@@ -1,0 +1,150 @@
+From 428205712f3ebd4efb7b0ea71d9fa45e0b28fece Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Wed, 8 Feb 2023 16:44:15 +1100
+Subject: [PATCH 4/4] Revert "[libc++] Remove workaround for C11 features on
+ compilers that don't support using_if_exists"
+
+This reverts commit 21f73d5826fb5024a27eaacafadfa316f58949c5.
+---
+ libcxx/include/__config | 66 +++++++++++++++++++++++++++++++++++++++++
+ libcxx/include/cstdlib  |  4 +--
+ libcxx/include/ctime    | 18 +++++++++--
+ 3 files changed, 84 insertions(+), 4 deletions(-)
+
+diff --git a/libcxx/include/__config b/libcxx/include/__config
+index 9759d3b9e8e0..9a27abe3367b 100644
+--- a/libcxx/include/__config
++++ b/libcxx/include/__config
+@@ -556,6 +556,72 @@
+ #    define _LIBCPP_NO_CFI
+ #  endif
+ 
++// If the compiler supports using_if_exists, pretend we have those functions and they'll
++// be picked up if the C library provides them.
++//
++// TODO: Once we drop support for Clang 12, we can assume the compiler supports using_if_exists
++//       for platforms that don't have a conforming C11 library, so we can drop this whole thing.
++#  if __has_attribute(using_if_exists)
++#    define _LIBCPP_HAS_TIMESPEC_GET
++#    define _LIBCPP_HAS_QUICK_EXIT
++#    define _LIBCPP_HAS_ALIGNED_ALLOC
++#  else
++#  if (defined(__ISO_C_VISIBLE) && (__ISO_C_VISIBLE >= 2011)) || __cplusplus >= 201103L
++#    if defined(__FreeBSD__)
++#      define _LIBCPP_HAS_ALIGNED_ALLOC
++#      define _LIBCPP_HAS_QUICK_EXIT
++#      if __FreeBSD_version >= 1300064 || \
++         (__FreeBSD_version >= 1201504 && __FreeBSD_version < 1300000)
++#        define _LIBCPP_HAS_TIMESPEC_GET
++#      endif
++#    elif defined(__BIONIC__)
++#      if __ANDROID_API__ >= 21
++#        define _LIBCPP_HAS_QUICK_EXIT
++#      endif
++#      if __ANDROID_API__ >= 28
++#        define _LIBCPP_HAS_ALIGNED_ALLOC
++#      endif
++#      if __ANDROID_API__ >= 29
++#        define _LIBCPP_HAS_TIMESPEC_GET
++#      endif
++#    elif defined(__Fuchsia__) || defined(__wasi__) || defined(__NetBSD__)
++#      define _LIBCPP_HAS_ALIGNED_ALLOC
++#      define _LIBCPP_HAS_QUICK_EXIT
++#      define _LIBCPP_HAS_TIMESPEC_GET
++#    elif defined(__OpenBSD__)
++#      define _LIBCPP_HAS_ALIGNED_ALLOC
++#      define _LIBCPP_HAS_TIMESPEC_GET
++#    elif defined(__linux__)
++#      if !defined(_LIBCPP_HAS_MUSL_LIBC)
++#        if _LIBCPP_GLIBC_PREREQ(2, 15) || defined(__BIONIC__)
++#          define _LIBCPP_HAS_QUICK_EXIT
++#        endif
++#        if _LIBCPP_GLIBC_PREREQ(2, 17)
++#          define _LIBCPP_HAS_ALIGNED_ALLOC
++#          define _LIBCPP_HAS_TIMESPEC_GET
++#        endif
++#      else // defined(_LIBCPP_HAS_MUSL_LIBC)
++#        define _LIBCPP_HAS_ALIGNED_ALLOC
++#        define _LIBCPP_HAS_QUICK_EXIT
++#        define _LIBCPP_HAS_TIMESPEC_GET
++#      endif
++#    elif defined(_LIBCPP_MSVCRT)
++     // Using Microsoft's C Runtime library, not MinGW
++#      define _LIBCPP_HAS_TIMESPEC_GET
++#    elif defined(__APPLE__)
++     // timespec_get and aligned_alloc were introduced in macOS 10.15 and
++     // aligned releases
++#      if ((defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 101500) || \
++           (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ >= 130000) || \
++           (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ >= 130000) || \
++           (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ >= 60000))
++#        define _LIBCPP_HAS_ALIGNED_ALLOC
++#        define _LIBCPP_HAS_TIMESPEC_GET
++#      endif
++#    endif // __APPLE__
++#  endif
++#  endif // __has_attribute(using_if_exists)
++
+ #  ifndef _LIBCPP_CXX03_LANG
+ 
+ #    define _LIBCPP_ALIGNOF(_Tp) alignof(_Tp)
+diff --git a/libcxx/include/cstdlib b/libcxx/include/cstdlib
+index ab2c159c7259..44a6f6a5dc36 100644
+--- a/libcxx/include/cstdlib
++++ b/libcxx/include/cstdlib
+@@ -140,11 +140,11 @@ using ::mbtowc _LIBCPP_USING_IF_EXISTS;
+ using ::wctomb _LIBCPP_USING_IF_EXISTS;
+ using ::mbstowcs _LIBCPP_USING_IF_EXISTS;
+ using ::wcstombs _LIBCPP_USING_IF_EXISTS;
+-#if !defined(_LIBCPP_CXX03_LANG)
++#if !defined(_LIBCPP_CXX03_LANG) && defined(_LIBCPP_HAS_QUICK_EXIT)
+ using ::at_quick_exit _LIBCPP_USING_IF_EXISTS;
+ using ::quick_exit _LIBCPP_USING_IF_EXISTS;
+ #endif
+-#if _LIBCPP_STD_VER >= 17
++#if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_HAS_ALIGNED_ALLOC)
+ using ::aligned_alloc _LIBCPP_USING_IF_EXISTS;
+ #endif
+ 
+diff --git a/libcxx/include/ctime b/libcxx/include/ctime
+index b61e19d6446d..6b48da7a7e4b 100644
+--- a/libcxx/include/ctime
++++ b/libcxx/include/ctime
+@@ -60,13 +60,27 @@ int timespec_get( struct timespec *ts, int base); // C++17
+ #  pragma GCC system_header
+ #endif
+ 
++// FIXME:
++// Apple SDKs don't define ::timespec_get unconditionally in C++ mode. This
++// should be fixed in future SDKs, but for the time being we need to avoid
++// trying to use that declaration when the SDK doesn't provide it. Note that
++// we're detecting this here instead of in <__config> because we can't include
++// system headers from <__config>, since it leads to circular module dependencies.
++// This is also meant to be a very temporary workaround until the SDKs are fixed.
++#if defined(__APPLE__) && !__has_attribute(using_if_exists)
++#   include <sys/cdefs.h>
++#   if defined(_LIBCPP_HAS_TIMESPEC_GET) && (__DARWIN_C_LEVEL < __DARWIN_C_FULL)
++#       define _LIBCPP_HAS_TIMESPEC_GET_NOT_ACTUALLY_PROVIDED
++#   endif
++#endif
++
+ _LIBCPP_BEGIN_NAMESPACE_STD
+ 
+ using ::clock_t _LIBCPP_USING_IF_EXISTS;
+ using ::size_t _LIBCPP_USING_IF_EXISTS;
+ using ::time_t _LIBCPP_USING_IF_EXISTS;
+ using ::tm _LIBCPP_USING_IF_EXISTS;
+-#if _LIBCPP_STD_VER >= 17
++#if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_HAS_TIMESPEC_GET)
+ using ::timespec _LIBCPP_USING_IF_EXISTS;
+ #endif
+ using ::clock _LIBCPP_USING_IF_EXISTS;
+@@ -78,7 +92,7 @@ using ::ctime _LIBCPP_USING_IF_EXISTS;
+ using ::gmtime _LIBCPP_USING_IF_EXISTS;
+ using ::localtime _LIBCPP_USING_IF_EXISTS;
+ using ::strftime _LIBCPP_USING_IF_EXISTS;
+-#if _LIBCPP_STD_VER >= 17
++#if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_HAS_TIMESPEC_GET) && !defined(_LIBCPP_HAS_TIMESPEC_GET_NOT_ACTUALLY_PROVIDED)
+ using ::timespec_get _LIBCPP_USING_IF_EXISTS;
+ #endif
+ 


### PR DESCRIPTION
From #127; let's see how far back in clang we can go without the revert for C11.