### PR TITLE
use existing libunwind on linux

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libunwind:
+- '1.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ Current release info
 Installing libcxx
 =================
 
-Installing `libcxx` from the `conda-forge/label/libcxx_macos_lt_12` channel can be achieved by adding `conda-forge/label/libcxx_macos_lt_12` to your channels with:
+Installing `libcxx` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
-conda config --add channels conda-forge/label/libcxx_macos_lt_12
+conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge/label/libcxx_macos_lt_12` channel has been enabled, `libcxx, libcxxabi` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libcxx, libcxxabi` can be installed with `conda`:
 
 ```
 conda install libcxx libcxxabi
@@ -104,26 +104,26 @@ mamba install libcxx libcxxabi
 It is possible to list all of the versions of `libcxx` available on your platform with `conda`:
 
 ```
-conda search libcxx --channel conda-forge/label/libcxx_macos_lt_12
+conda search libcxx --channel conda-forge
 ```
 
 or with `mamba`:
 
 ```
-mamba search libcxx --channel conda-forge/label/libcxx_macos_lt_12
+mamba search libcxx --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search libcxx --channel conda-forge/label/libcxx_macos_lt_12
+mamba repoquery search libcxx --channel conda-forge
 
 # List packages depending on `libcxx`:
-mamba repoquery whoneeds libcxx --channel conda-forge/label/libcxx_macos_lt_12
+mamba repoquery whoneeds libcxx --channel conda-forge
 
 # List dependencies of `libcxx`:
-mamba repoquery depends libcxx --channel conda-forge/label/libcxx_macos_lt_12
+mamba repoquery depends libcxx --channel conda-forge
 ```
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,4 +41,13 @@ if [[ "$target_platform" == osx-* ]]; then
     $INSTALL_NAME_TOOL -change "@rpath/libc++abi.1.dylib" "/usr/lib/libc++abi.dylib" $PREFIX/lib/libc++.1.0.dylib
     # same for libunwind
     $INSTALL_NAME_TOOL -change "@rpath/libunwind.1.dylib" "/usr/lib/system/libunwind.dylib" $PREFIX/lib/libc++.1.0.dylib
+else
+    # point libcxxabi & libcxx (the actual libs, not the symlinks) to the
+    # libunwind from https://github.com/conda-forge/libunwind-feedstock
+    for f in $PREFIX/lib/libc++abi.so.1.0 $PREFIX/lib/libc++.so.1.0; do
+        # first SOVER is the one from LLVM, the second is what we're replacing it with
+        patchelf --replace-needed libunwind.so.1 libunwind.so.8 --output patched $f
+        chmod +x patched
+        mv patched $f
+    done
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
       - patches/0006-Work-around-stray-nostdlib-flags-causing-errors-with.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   skip: true  # [ppc64le or aarch64]
   ignore_run_exports:
@@ -40,9 +40,11 @@ requirements:
     - {{ stdlib('c') }}       # [osx and (sys_abi == "pre-12")]
     - {{ stdlib('c') }}       # [osx and (sys_abi == "post-12")]
     - python >3               # [not osx]
+    - patchelf                # [linux]
   host:
     - clangdev {{ version }}  # [not osx]
     - llvmdev {{ version }}   # [not osx]
+    - libunwind               # [linux]
 
 outputs:
   - name: libcxx
@@ -60,6 +62,7 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
       host:
+        - {{ pin_subpackage("libcxxabi", exact=True) }}    # [linux]
       run:
         - {{ pin_subpackage("libcxxabi", exact=True) }}    # [linux]
       run_constrained:
@@ -122,26 +125,13 @@ outputs:
       build:
         # for run-exports
         - {{ stdlib('c') }}
+      host:
+        - libunwind     # [linux]
       run:
-        - {{ pin_subpackage("libunwind", exact=True) }}  # [linux]
+        - libunwind     # [linux]
     test:
       commands:
         - test -f $PREFIX/lib/libc++abi.so  # [linux]
-
-  - name: libunwind
-    build:
-      skip: true  # [not linux]
-    files:
-      - lib/libunwind.*
-    requirements:
-      build:
-        # for run-exports
-        - {{ stdlib('c') }}
-      run_constrained:
-        - libcxx {{ version }}.*
-    test:
-      commands:
-        - test -f $PREFIX/lib/libunwind.so  # [linux]
 
 about:
   home: http://libcxx.llvm.org/


### PR DESCRIPTION
Not sure if this is possible, but it would be nice... Follow-up to #155

The LLVM [docs](https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/clang/docs/Toolchain.rst#libunwind-nongnuorg) at least make this sound possible.

Closes #161