### PR TITLE
run ld64 downstream tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,6 +110,8 @@ outputs:
         - libcxx-testing 0.17   # [osx]
         - libcxx-testing 0.16   # [osx]
         - libcxx-testing 0.15   # [osx]
+        # issue from #162 shows up for ld
+        - ld64_osx-64           # [osx]
     {% endif %}
 
   - name: libcxxabi


### PR DESCRIPTION
For #162; see if we can reproduce the test failures from https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/68 in CI here directly