### PR TITLE
Bootstrap `libcxx-devel` as wrapper around `libcxx`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,8 +103,6 @@ outputs:
       downstreams:              # [osx]
         - python-symengine      # [osx]
         - openturns             # [osx]
-      # disabled until libcxx-testing depends on `libcxx-devel`
-      {% if False %}
         # test current libcxx against old clang builds;
         # version correspondence is 0.{{ CLANG_MAJOR }}
         # these tests are unusual in that they use -Wl,-rpath, but not -L.
@@ -112,7 +110,6 @@ outputs:
         - libcxx-testing 0.17   # [osx]
         - libcxx-testing 0.16   # [osx]
         - libcxx-testing 0.15   # [osx]
-      {% endif %}
     {% endif %}
 
   - name: libcxx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
       - patches/0004-Work-around-stray-nostdlib-flags-causing-errors-with.patch
 
 build:
-  number: 5
+  number: 6
   skip: true  # [win]
   skip: true  # [ppc64le or aarch64]
 
@@ -50,13 +50,14 @@ outputs:
       run_exports:                                      # [hardening == "debug"]
         # packages built with hardened lib must not be installable without extra label
         - libcxx =*=debug*                              # [hardening == "debug"]
-    files:
-      - include/c++                 # [unix]
-      - lib/libc++.a                # [unix]
-      - lib/libc++experimental.*    # [unix]
-      - Library/include/c++         # [win]
-      - Library/lib/c++*.lib        # [win]
-      - Library/lib/libc++*.lib     # [win]
+    # temporarily still in libcxx, until we update compiler stack w.r.t. libcxx-devel
+    # files:
+    #   - include/c++                 # [unix]
+    #   - lib/libc++.a                # [unix]
+    #   - lib/libc++experimental.*    # [unix]
+    #   - Library/include/c++         # [win]
+    #   - Library/lib/c++*.lib        # [win]
+    #   - Library/lib/libc++*.lib     # [win]
     requirements:
       host:
         - {{ pin_subpackage("libcxx", exact=True) }}
@@ -131,6 +132,13 @@ outputs:
       - lib/libc++.dylib            # [osx]
       - lib/libc++.*.dylib          # [osx]
       - Library/bin/c++*.dll        # [win]
+    # temporarily still in libcxx, until we update compiler stack w.r.t. libcxx-devel
+      - include/c++                 # [unix]
+      - lib/libc++.a                # [unix]
+      - lib/libc++experimental.*    # [unix]
+      - Library/include/c++         # [win]
+      - Library/lib/c++*.lib        # [win]
+      - Library/lib/libc++*.lib     # [win]
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -148,9 +156,9 @@ outputs:
         - test -f $PREFIX/lib/libc++.so                 # [linux]
         - test -f $PREFIX/lib/libc++.dylib              # [osx]
         # absence of static libs & headers
-        - test ! -f $PREFIX/lib/libc++.a                # [unix]
-        - test ! -f $PREFIX/lib/libc++experimental.a    # [unix]
-        - test ! -d $PREFIX/include/c++                 # [unix]
+        # - test ! -f $PREFIX/lib/libc++.a                # [unix]
+        # - test ! -f $PREFIX/lib/libc++experimental.a    # [unix]
+        # - test ! -d $PREFIX/include/c++                 # [unix]
 
   - name: libcxxabi
     build:


### PR DESCRIPTION
Retry #183 in a way that doesn't break compilers before we merge https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/138 (after which we can revert 74204e6b81777c3ccf7f43ecac6ad8046ca7a59f again)