### PR TITLE
[16.x] Re-enable downstream testing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "16.0.6" %}
+{% set major = version.split(".")[0] %}
 
 {% if sys_abi is undefined %}
 {% set sys_abi = "dummy" %}
@@ -97,14 +98,14 @@ outputs:
         - python-symengine      # [osx]
         - openturns             # [osx]
         # test current libcxx against old clang builds;
-        # version correspondence is 0.{{ CLANG_MAJOR }}
+        # version correspondence is 0.{{ CLANG_MAJOR }}.{{ LIBCXX_MAJOR }}
         # these tests are unusual in that they use -Wl,-rpath, but not -L.
-        - libcxx-testing 0.16   # [osx]
-        - libcxx-testing 0.15   # [osx]
-        - libcxx-testing 0.14   # [osx]
-        - libcxx-testing 0.13   # [osx]
-        - libcxx-testing 0.12   # [osx]
-        - libcxx-testing 0.11   # [osx]
+        - libcxx-testing 0.16.{{ major }}   # [osx]
+        - libcxx-testing 0.15.{{ major }}   # [osx]
+        - libcxx-testing 0.14.{{ major }}   # [osx]
+        - libcxx-testing 0.13.{{ major }}   # [osx]
+        - libcxx-testing 0.12.{{ major }}   # [osx]
+        - libcxx-testing 0.11.{{ major }}   # [osx]
     {% endif %}
 
   - name: libcxx


### PR DESCRIPTION
Leveraging https://github.com/conda-forge/libcxx-testing-feedstock/pull/9