### PR TITLE
Split off headers into `libcxx-devel`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,14 +50,13 @@ outputs:
       run_exports:                                      # [hardening == "debug"]
         # packages built with hardened lib must not be installable without extra label
         - libcxx =*=debug*                              # [hardening == "debug"]
-    # temporarily still in libcxx, until we update compiler stack w.r.t. libcxx-devel
-    # files:
-    #   - include/c++                 # [unix]
-    #   - lib/libc++.a                # [unix]
-    #   - lib/libc++experimental.*    # [unix]
-    #   - Library/include/c++         # [win]
-    #   - Library/lib/c++*.lib        # [win]
-    #   - Library/lib/libc++*.lib     # [win]
+    files:
+      - include/c++                 # [unix]
+      - lib/libc++.a                # [unix]
+      - lib/libc++experimental.*    # [unix]
+      - Library/include/c++         # [win]
+      - Library/lib/c++*.lib        # [win]
+      - Library/lib/libc++*.lib     # [win]
     requirements:
       host:
         - {{ pin_subpackage("libcxx", exact=True) }}
@@ -129,13 +128,6 @@ outputs:
       - lib/libc++.dylib            # [osx]
       - lib/libc++.*.dylib          # [osx]
       - Library/bin/c++*.dll        # [win]
-    # temporarily still in libcxx, until we update compiler stack w.r.t. libcxx-devel
-      - include/c++                 # [unix]
-      - lib/libc++.a                # [unix]
-      - lib/libc++experimental.*    # [unix]
-      - Library/include/c++         # [win]
-      - Library/lib/c++*.lib        # [win]
-      - Library/lib/libc++*.lib     # [win]
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -153,9 +145,9 @@ outputs:
         - test -f $PREFIX/lib/libc++.so                 # [linux]
         - test -f $PREFIX/lib/libc++.dylib              # [osx]
         # absence of static libs & headers
-        # - test ! -f $PREFIX/lib/libc++.a                # [unix]
-        # - test ! -f $PREFIX/lib/libc++experimental.a    # [unix]
-        # - test ! -d $PREFIX/include/c++                 # [unix]
+        - test ! -f $PREFIX/lib/libc++.a                # [unix]
+        - test ! -f $PREFIX/lib/libc++experimental.a    # [unix]
+        - test ! -d $PREFIX/include/c++                 # [unix]
 
   - name: libcxxabi
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
       - patches/0004-Work-around-stray-nostdlib-flags-causing-errors-with.patch
 
 build:
-  number: 6
+  number: 7
   skip: true  # [win]
   skip: true  # [ppc64le or aarch64]
 
@@ -52,11 +52,7 @@ outputs:
         - libcxx =*=debug*                              # [hardening == "debug"]
     files:
       - include/c++                 # [unix]
-      - lib/libc++.a                # [unix]
-      - lib/libc++experimental.*    # [unix]
       - Library/include/c++         # [win]
-      - Library/lib/c++*.lib        # [win]
-      - Library/lib/libc++*.lib     # [win]
     requirements:
       host:
         - {{ pin_subpackage("libcxx", exact=True) }}
@@ -128,6 +124,10 @@ outputs:
       - lib/libc++.dylib            # [osx]
       - lib/libc++.*.dylib          # [osx]
       - Library/bin/c++*.dll        # [win]
+      - lib/libc++.a                # [unix]
+      - lib/libc++experimental.*    # [unix]
+      - Library/lib/c++*.lib        # [win]
+      - Library/lib/libc++*.lib     # [win]
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -141,12 +141,12 @@ outputs:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
     test:
       commands:
-        # presence of shared libraries
+        # presence of shared & static libraries
         - test -f $PREFIX/lib/libc++.so                 # [linux]
         - test -f $PREFIX/lib/libc++.dylib              # [osx]
-        # absence of static libs & headers
-        - test ! -f $PREFIX/lib/libc++.a                # [unix]
-        - test ! -f $PREFIX/lib/libc++experimental.a    # [unix]
+        - test -f $PREFIX/lib/libc++.a                  # [unix]
+        - test -f $PREFIX/lib/libc++experimental.a      # [unix]
+        # absence of headers
         - test ! -d $PREFIX/include/c++                 # [unix]
 
   - name: libcxxabi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ outputs:
       host:
         - {{ pin_subpackage("libcxx", exact=True) }}
       run:
-        - {{ pin_subpackage("libcxx", exact=True) }}
+        - {{ pin_subpackage("libcxx", max_pin=None) }}
       run_constrained:
         - __osx <12     # [osx and (sys_abi == "pre-12")]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - {{ stdlib('c') }}
     - python >3               # [not osx]
   host:
-    - clangdev {{ version }}  # [not osx]
+    # - clangdev {{ version }}  # [not osx]
     - llvmdev {{ version }}   # [not osx]
 
 outputs:


### PR DESCRIPTION
Redo #183 after #187 and https://github.com/conda-forge/clangdev-feedstock/pull/311 prepared the way.