### PR TITLE
[16.x] Split off headers into `libcxx-devel`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,14 +44,13 @@ requirements:
 
 outputs:
   - name: libcxx-devel
-    # temporarily still in libcxx, until we update compiler stack w.r.t. libcxx-devel
-    # files:
-    #   - include/c++                 # [unix]
-    #   - lib/libc++.a                # [unix]
-    #   - lib/libc++experimental.*    # [unix]
-    #   - Library/include/c++         # [win]
-    #   - Library/lib/c++*.lib        # [win]
-    #   - Library/lib/libc++*.lib     # [win]
+    files:
+      - include/c++                 # [unix]
+      - lib/libc++.a                # [unix]
+      - lib/libc++experimental.*    # [unix]
+      - Library/include/c++         # [win]
+      - Library/lib/c++*.lib        # [win]
+      - Library/lib/libc++*.lib     # [win]
     requirements:
       host:
         - {{ pin_subpackage("libcxx", exact=True) }}
@@ -125,13 +124,6 @@ outputs:
       - lib/libc++.dylib            # [osx]
       - lib/libc++.*.dylib          # [osx]
       - Library/bin/c++*.dll        # [win]
-    # temporarily still in libcxx, until we update compiler stack w.r.t. libcxx-devel
-      - include/c++                 # [unix]
-      - lib/libc++.a                # [unix]
-      - lib/libc++experimental.*    # [unix]
-      - Library/include/c++         # [win]
-      - Library/lib/c++*.lib        # [win]
-      - Library/lib/libc++*.lib     # [win]
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -149,9 +141,9 @@ outputs:
         - test -f $PREFIX/lib/libc++.so                 # [linux]
         - test -f $PREFIX/lib/libc++.dylib              # [osx]
         # absence of static libs & headers
-        # - test ! -f $PREFIX/lib/libc++.a                # [unix]
-        # - test ! -f $PREFIX/lib/libc++experimental.a    # [unix]
-        # - test ! -d $PREFIX/include/c++                 # [unix]
+        - test ! -f $PREFIX/lib/libc++.a                # [unix]
+        - test ! -f $PREFIX/lib/libc++experimental.a    # [unix]
+        - test ! -d $PREFIX/include/c++                 # [unix]
 
   - name: libcxxabi
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ outputs:
       host:
         - {{ pin_subpackage("libcxx", exact=True) }}
       run:
-        - {{ pin_subpackage("libcxx", exact=True) }}
+        - {{ pin_subpackage("libcxx", max_pin=None) }}
       run_constrained:
         - __osx <12     # [osx and (sys_abi == "pre-12")]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
       - patches/0005-Revert-libc-Remove-workaround-for-C11-features-on-co.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   skip: true  # [ppc64le or aarch64]
 
@@ -46,11 +46,7 @@ outputs:
   - name: libcxx-devel
     files:
       - include/c++                 # [unix]
-      - lib/libc++.a                # [unix]
-      - lib/libc++experimental.*    # [unix]
       - Library/include/c++         # [win]
-      - Library/lib/c++*.lib        # [win]
-      - Library/lib/libc++*.lib     # [win]
     requirements:
       host:
         - {{ pin_subpackage("libcxx", exact=True) }}
@@ -124,6 +120,10 @@ outputs:
       - lib/libc++.dylib            # [osx]
       - lib/libc++.*.dylib          # [osx]
       - Library/bin/c++*.dll        # [win]
+      - lib/libc++.a                # [unix]
+      - lib/libc++experimental.*    # [unix]
+      - Library/lib/c++*.lib        # [win]
+      - Library/lib/libc++*.lib     # [win]
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -137,12 +137,12 @@ outputs:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
     test:
       commands:
-        # presence of shared libraries
+        # presence of shared & static libraries
         - test -f $PREFIX/lib/libc++.so                 # [linux]
         - test -f $PREFIX/lib/libc++.dylib              # [osx]
-        # absence of static libs & headers
-        - test ! -f $PREFIX/lib/libc++.a                # [unix]
-        - test ! -f $PREFIX/lib/libc++experimental.a    # [unix]
+        - test -f $PREFIX/lib/libc++.a                  # [unix]
+        - test -f $PREFIX/lib/libc++experimental.a      # [unix]
+        # absence of headers
         - test ! -d $PREFIX/include/c++                 # [unix]
 
   - name: libcxxabi


### PR DESCRIPTION
Actually do the split after #185 and https://github.com/conda-forge/clangdev-feedstock/pull/313 prepared the way.