### PR TITLE
Enable leapsecond tests for tzdb

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-24.04
   strategy:
     matrix:
       linux_64_channel_targetsconda-forge_libcxx_debughardeningdebug:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macos-14
+    vmImage: macos-15
   strategy:
     matrix:
       osx_64_channel_targetsconda-forge_libcxx_debughardeningdebugsys_abipost-12:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,32 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
-jobs:
-  - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-osx.yml
+stages:
+- stage: Check
+  jobs:
+    - job: Skip
+      pool:
+        vmImage: 'ubuntu-22.04'
+      variables:
+        DECODE_PERCENTS: 'false'
+        RET: 'true'
+      steps:
+      - checkout: self
+        
+        fetchDepth: '2'
+      - bash: |
+          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
+          echo "##vso[task.setvariable variable=log]$git_log"
+        displayName: Obtain commit message
+      - bash: echo "##vso[task.setvariable variable=RET]false"
+        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        displayName: Skip build?
+      - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
+        name: result
+        displayName: Export result
+- stage: Build
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
+  jobs:
+    - template: ./.azure-pipelines/azure-pipelines-linux.yml
+    - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,7 @@
 azure:
+  settings_linux:
+    pool:
+      vmImage: ubuntu-24.04
   settings_osx:
     pool:
       vmImage: macos-14

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,7 +4,7 @@ azure:
       vmImage: ubuntu-24.04
   settings_osx:
     pool:
-      vmImage: macos-14
+      vmImage: macos-15
 bot:
   abi_migration_branches:
   - 18.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,8 +58,8 @@ outputs:
       host:
         - {{ pin_subpackage("libcxx", exact=True) }}
       run:
-        # re-enable this once chrono implementation is in shared library
-        # - tzdata
+        # re-enable this for osx once chrono implementation is in shared library
+        - tzdata  # [linux]
         - {{ pin_subpackage("libcxx", max_pin=None) }}
       run_constrained:
         - __osx <12     # [osx and (sys_abi == "pre-12")]
@@ -96,12 +96,11 @@ outputs:
         - test -f $PREFIX/lib/libc++abi.so                        # [linux]
 
         # for full chrono support, libcxx needs leap-seconds.list, which
-        # isn't shipped in ubuntu-22.04 nor macos-14 images (ubuntu-24.04
-        # should have it, but isn't available in azure pipelines yet).
+        # isn't shipped macos-14 image
         - ls -lL /usr/share/zoneinfo
         # This check is intended to start failing once an image starts shipping
         # that file, so we can re-enable the leapsecond portion of the tzdb-tests
-        - if [ 0 -ne $(ls -lL /usr/share/zoneinfo | grep leap-seconds.list | wc -l) ]; then exit 1; fi
+        - if [ 0 -ne $(ls -lL /usr/share/zoneinfo | grep leap-seconds.list | wc -l) ]; then exit 1; fi  # [osx]
 
         - bash compile_test.sh                                    # [unix]
         - compile_test.bat                                        # [win]

--- a/recipe/test_sources/tzdb/tzdb.cpp
+++ b/recipe/test_sources/tzdb/tzdb.cpp
@@ -86,8 +86,10 @@ test_load_leapseconds()
   std::printf("found %zu leapseconds\n", len);
 
   // this is correct as of tzdata 2024a
-  // disabled currently due to missing leap-seconds.list, see meta.yaml
-  // VERIFY( db.leap_seconds.size() == 27 );
+  // disabled currently due to missing leap-seconds.list on osx, see meta.yaml
+#if defined(__linux__)
+  VERIFY( db.leap_seconds.size() == 27 );
+#endif
 }
 
 int main()


### PR DESCRIPTION
Descoped from #178 because the then-available images didn't contain the necessary `leap-seconds.list` (and we cannot point to our own `tzdata` while chrono support is experimental and thus in a static library).

Try again with newer images.