### PR TITLE
[19.x] pin downstream tests to libcxx version we're building

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "19.1.7" %}
+{% set major = version.split(".")[0] %}
 
 {% if sys_abi is undefined %}
 {% set sys_abi = "dummy" %}
@@ -111,12 +112,12 @@ outputs:
         - python-symengine      # [osx]
         - openturns             # [osx]
         # test current libcxx against old clang builds;
-        # version correspondence is 0.{{ CLANG_MAJOR }}
+        # version correspondence is 0.{{ CLANG_MAJOR }}.{{ LIBCXX_MAJOR }}
         # these tests are unusual in that they use -Wl,-rpath, but not -L.
-        - libcxx-testing 0.19   # [osx]
-        - libcxx-testing 0.18   # [osx]
-        - libcxx-testing 0.17   # [osx]
-        - libcxx-testing 0.16   # [osx]
+        - libcxx-testing 0.19.{{ major }}   # [osx]
+        - libcxx-testing 0.18.{{ major }}   # [osx]
+        - libcxx-testing 0.17.{{ major }}   # [osx]
+        - libcxx-testing 0.16.{{ major }}   # [osx]
     {% endif %}
 
   - name: libcxx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
       - patches/0005-runtimes-Probe-for-nostdlib-and-nostdinc-with-the-C-.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   skip: true  # [ppc64le or aarch64]
 


### PR DESCRIPTION
Otherwise, libcxx-testing might end up testing _another_ (newer) libcxx version than the one we're building on the maintenance branches, see https://github.com/conda-forge/libcxx-testing-feedstock/pull/9